### PR TITLE
fix(claude): set onboarding marker on the credentials auth path

### DIFF
--- a/internal/sandbox/oauth_token.go
+++ b/internal/sandbox/oauth_token.go
@@ -133,9 +133,9 @@ func ClearOAuthToken(clawkRootDir string) error {
 // fresh sandboxes drop the user straight into the agent without an
 // interactive setup dance:
 //
-//   - hasCompletedOnboarding: bypasses the theme + auth wizard. Only
-//     useful when CLAUDE_CODE_OAUTH_TOKEN is in play; the keychain
-//     path carries its own account metadata.
+//   - hasCompletedOnboarding: bypasses the theme + auth wizard. Needed
+//     by BOTH auth paths — the wizard's login step fires on the flag
+//     alone and never checks whether usable credentials already exist.
 //     See anthropics/claude-code#8938, #4714.
 //
 //   - projects[<path>].hasTrustDialogAccepted: bypasses the
@@ -152,8 +152,14 @@ const guestClaudeJSONPath = GuestHome + "/.claude.json"
 // ClaudeJSONMarkerFile returns the HostFile that
 // pre-creates ~/.claude.json. Two concerns share the file:
 //
-//   - hasCompletedOnboarding (only when hasToken — the keychain
-//     credentials path doesn't need it).
+//   - hasCompletedOnboarding, whenever the sandbox boots with usable
+//     credentials (hasAuth) — either a long-lived token or a seeded
+//     .credentials.json. ~/.claude.json lives on the per-boot
+//     disposable rootfs, so this marker IS the file claude reads at
+//     every startup; without the flag it re-runs the first-run wizard
+//     — including its OAuth step, which fires on the flag alone and
+//     never looks at the credentials sitting in ~/.claude/. The agent
+//     is asked to log in on every boot despite valid credentials.
 //   - hasTrustDialogAccepted=true for every phase worktree path the
 //     sandbox mounts, the per-repo source mounts those worktrees
 //     point at, and the workspace root. Without these, a fresh
@@ -161,12 +167,16 @@ const guestClaudeJSONPath = GuestHome + "/.claude.json"
 //     launch in each directory — a 100% pointless gate in a VM whose
 //     only contents the user just chose to mount.
 //
+// hasAuth=false leaves the flag off deliberately: with no credentials
+// to skip to, suppressing the wizard would strand the agent in a REPL
+// it can't authenticate from. The wizard's login step is the way out.
+//
 // Always emitted: the trust block is sandbox-shape-dependent (we
 // only know the paths after PrepareVM resolves phases), but it's
 // always wanted.
-func ClaudeJSONMarkerFile(phases []config.Phase, hasToken bool) HostFile {
+func ClaudeJSONMarkerFile(phases []config.Phase, hasAuth bool) HostFile {
 	doc := map[string]any{}
-	if hasToken {
+	if hasAuth {
 		doc["hasCompletedOnboarding"] = true
 	}
 

--- a/internal/sandbox/oauth_token_test.go
+++ b/internal/sandbox/oauth_token_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/clawkwork/clawk/internal/config"
+	"github.com/clawkwork/clawk/internal/guestcfg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -218,17 +219,95 @@ func TestClaudeJSONMarkerFilePreTrustsPhases(t *testing.T) {
 	}
 }
 
-// TestClaudeJSONMarkerFileOmitsOnboardingWithoutToken keeps the
-// "onboarding marker is scoped to the token path" property — the
-// keychain-credentials flow ships its own account metadata.
-func TestClaudeJSONMarkerFileOmitsOnboardingWithoutToken(t *testing.T) {
+// TestClaudeJSONMarkerFileOmitsOnboardingWithoutAuth keeps the flag off
+// for a sandbox that has no credentials at all: the first-run wizard's
+// login step is the only way such a sandbox can authenticate, so
+// suppressing it would strand the agent in a REPL it can't sign into.
+func TestClaudeJSONMarkerFileOmitsOnboardingWithoutAuth(t *testing.T) {
 	hf := ClaudeJSONMarkerFile(nil, false)
 	var doc map[string]any
 	require.NoErrorf(t, json.Unmarshal(hf.Content, &doc), "marker content not valid JSON")
 	if _, set := doc["hasCompletedOnboarding"]; set {
-		t.Error("hasCompletedOnboarding should be absent without a token " +
-			"(keychain creds carry their own account metadata)")
+		t.Error("hasCompletedOnboarding should be absent with no credentials — " +
+			"the login wizard is the sandbox's only way in")
 	}
+}
+
+// TestStateDirHasCredentials pins the predicate the marker keys off:
+// present only once .credentials.json is in the mounted state dir.
+func TestStateDirHasCredentials(t *testing.T) {
+	state := t.TempDir()
+	if StateDirHasCredentials(state) {
+		t.Error("empty state dir reported credentials")
+	}
+	if StateDirHasCredentials("") {
+		t.Error("opted-out state dir reported credentials")
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(state, "claude"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(state, "claude", ".credentials.json"), []byte(`{}`), 0o600))
+	if !StateDirHasCredentials(state) {
+		t.Error("seeded .credentials.json not detected")
+	}
+}
+
+// TestGuestManifestMarksOnboardingForCredentialsPath is the regression
+// test for clawkwork/clawk#8. ~/.claude.json lives on the per-boot
+// disposable rootfs, so this marker is the whole file claude reads at
+// startup: without the flag, a sandbox authenticated by seeded keychain
+// credentials re-runs the first-run wizard — and is asked to log in —
+// on every single boot.
+func TestGuestManifestMarksOnboardingForCredentialsPath(t *testing.T) {
+	clawkRoot := t.TempDir()
+	state := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	require.NoError(t, os.MkdirAll(filepath.Join(state, "claude"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(state, "claude", ".credentials.json"), []byte(`{}`), 0o600))
+
+	sb := &config.Sandbox{Name: "box", Image: "golang:1.25"}
+	m, err := OCIGuestManifest(sb, state, "", clawkRoot)
+	require.NoErrorf(t, err, "OCIGuestManifest")
+
+	doc := markerDocFromManifest(t, m)
+	if doc["hasCompletedOnboarding"] != true {
+		t.Errorf("hasCompletedOnboarding = %v, want true — seeded credentials "+
+			"are unreachable while the onboarding wizard runs", doc["hasCompletedOnboarding"])
+	}
+}
+
+// TestGuestManifestOmitsOnboardingWithoutAnyAuth is the other half of
+// the contract: no token, no credentials, no flag.
+func TestGuestManifestOmitsOnboardingWithoutAnyAuth(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+
+	sb := &config.Sandbox{Name: "box", Image: "golang:1.25"}
+	m, err := OCIGuestManifest(sb, t.TempDir(), "", t.TempDir())
+	require.NoErrorf(t, err, "OCIGuestManifest")
+
+	doc := markerDocFromManifest(t, m)
+	if _, set := doc["hasCompletedOnboarding"]; set {
+		t.Error("hasCompletedOnboarding set with neither token nor credentials")
+	}
+}
+
+// markerDocFromManifest returns the parsed ~/.claude.json the guest will
+// boot with, failing the test if the manifest doesn't carry one.
+func markerDocFromManifest(t *testing.T, m guestcfg.Manifest) map[string]any {
+	t.Helper()
+	for _, f := range m.Files {
+		if f.Path != guestClaudeJSONPath {
+			continue
+		}
+		var doc map[string]any
+		require.NoErrorf(t, json.Unmarshal(f.Content, &doc),
+			"marker content not valid JSON: %s", f.Content)
+		return doc
+	}
+	t.Fatalf("manifest has no %s file", guestClaudeJSONPath)
+	return nil
 }
 
 // TestSeedClaudeStateDirWritesSettings checks that the synthesized

--- a/internal/sandbox/oci_sandbox.go
+++ b/internal/sandbox/oci_sandbox.go
@@ -169,8 +169,13 @@ func OCIGuestManifest(sb *config.Sandbox, stateDir, cacheDir, rootDir string) (g
 
 	// Snapshot files — the write_files: equivalent.
 	token, _ := LoadOAuthToken(rootDir)
+	// Both auth paths need the onboarding marker: a seeded
+	// .credentials.json is only reachable once claude skips its
+	// first-run wizard. SeedClaudeStateDir has already run by here
+	// (provider Create), so the state dir is authoritative.
+	hasAuth := token != "" || StateDirHasCredentials(stateDir)
 	files := append(DefaultHostFiles(rootDir), WorkspaceDocFile(sb))
-	files = append(files, ClaudeJSONMarkerFile(sb.Phases, token != ""))
+	files = append(files, ClaudeJSONMarkerFile(sb.Phases, hasAuth))
 	envFile, ok, err := EnvFile(sb)
 	if err != nil {
 		return guestcfg.Manifest{}, err

--- a/internal/sandbox/shares.go
+++ b/internal/sandbox/shares.go
@@ -172,7 +172,7 @@ func SeedClaudeStateDir(stateRoot, clawkRootDir string) error {
 	if token, _ := LoadOAuthToken(clawkRootDir); token != "" {
 		return nil
 	}
-	credPath := filepath.Join(dst, ".credentials.json")
+	credPath := claudeCredentialsPath(stateRoot)
 	if _, err := os.Stat(credPath); err == nil {
 		// Already persisted — claude has been refreshing in-place; don't
 		// clobber a fresher copy with a stale keychain snapshot.
@@ -184,6 +184,30 @@ func SeedClaudeStateDir(stateRoot, clawkRootDir string) error {
 		}
 	}
 	return nil
+}
+
+// claudeCredentialsPath is where claude reads and refreshes its OAuth
+// credentials, in host terms: inside the per-sandbox state dir that
+// PersistentClaudeShares mounts at ~/.claude/.
+func claudeCredentialsPath(stateRoot string) string {
+	return filepath.Join(stateRoot, "claude", ".credentials.json")
+}
+
+// StateDirHasCredentials reports whether the sandbox will boot with
+// keychain-path credentials in place — either just seeded by
+// SeedClaudeStateDir or persisted (and refreshed) by a previous session.
+//
+// Callers use it to decide the onboarding marker: credentials are only
+// usable if claude skips its first-run wizard, and the wizard's login
+// step never checks for them (see ClaudeJSONMarkerFile). Runs after
+// SeedClaudeStateDir in every boot path, so a first boot sees the file
+// the seed just wrote.
+func StateDirHasCredentials(stateRoot string) bool {
+	if stateRoot == "" {
+		return false
+	}
+	_, err := os.Stat(claudeCredentialsPath(stateRoot))
+	return err == nil
 }
 
 // SeedClaudeMemory writes seed into the agent's auto-memory entrypoint


### PR DESCRIPTION
Fixes #8.

## The bug

`~/.claude.json` lives on the rootfs, which vz re-clones from the pristine image on every boot (`oci.Materialize` → `cow.Clone`, and `clawk down` discards the suspend snapshot so the next boot is cold). So the marker `clawk-init` writes from the guest manifest isn't layered over anything — it *is* the whole file claude reads at startup.

That marker set `hasCompletedOnboarding` only when a long-lived OAuth token was configured, on the premise that the keychain-credentials path "carries its own account metadata". It doesn't — `.credentials.json` holds tokens and scopes, nothing else. And claude's first-run wizard gates on `hasCompletedOnboarding` alone; its OAuth step is pushed purely on `isAnthropicAuthEnabled()` and never checks whether usable credentials already exist.

Net effect on the credentials path: every boot re-ran onboarding and asked the agent to log in, despite a valid `~/.claude/.credentials.json` persisting in the state-dir mount. (`theme` is not a second trigger — `getConfig` merges the file over defaults, which set `theme: 'dark'`.)

## The fix

Key the flag on "this sandbox boots with usable credentials" rather than "a token is configured":

```go
hasAuth := token != "" || StateDirHasCredentials(stateDir)
```

`StateDirHasCredentials` looks for `.credentials.json` in the per-sandbox state dir — either just written by `SeedClaudeStateDir`, or persisted and refreshed by a previous session. `SeedClaudeStateDir` runs in the provider's `Create`, before the daemon builds the manifest at `Start`, so a first boot sees the file the seed just wrote.

With neither token nor credentials the flag stays off deliberately: suppressing the wizard there would strand the agent in a REPL it has no way to sign into.

## Tests

- `TestGuestManifestMarksOnboardingForCredentialsPath` — the regression test, driven end-to-end through `OCIGuestManifest` so it covers the wiring and not just the marker function. Verified non-vacuous: reverting the call site to `token != ""` fails it.
- `TestGuestManifestOmitsOnboardingWithoutAnyAuth` — the other half of the contract.
- `TestStateDirHasCredentials` — the predicate, including the `stateRoot == ""` opt-out.
- `TestClaudeJSONMarkerFileOmitsOnboardingWithoutToken` → `…WithoutAuth`, re-pointed at the no-credentials case; it previously pinned the buggy behaviour.

`go build ./...`, `go vet ./...`, `go test ./...` all clean.

## Out of scope

Two things the issue touches that this doesn't change:

- **Everything else in `~/.claude.json` is still lost on every cold boot** — `oauthAccount`, `userID`, `mcpServers`, `tipsHistory`, per-project prompt `history`. The token path was only asymptomatically fine because the marker re-asserted the one user-visible flag. Fixing that properly means moving the file into the persistent mount (`CLAUDE_CONFIG_DIR=/home/agent/.claude`, or a symlink — claude's config writer resolves and writes *through* symlinks) and turning the marker into a merge, since the trust block changes with the phase list.
- **A snapshot-restored boot was never affected.** `clawk-init` doesn't re-run and `suspendBootRootFS` keeps the existing disk, so the marker isn't re-pushed there — contrary to the note at the end of the issue, that path needs no `on up` hook.

- **The firecracker provider emits no manifest `Files` at all**, so it gets neither the onboarding flag nor the trust pre-acceptance. Separate gap, same area.
